### PR TITLE
Fixed error when converting old savegames

### DIFF
--- a/widescreen/libsmall/patch_sav.tpa
+++ b/widescreen/libsmall/patch_sav.tpa
@@ -15,6 +15,7 @@ DEFINE_ACTION_MACRO ~patch_this_one~ BEGIN
         PATCH_IF ~%SAV_EXT%~ STRING_EQUAL_CASE ~ARE~ THEN BEGIN
           READ_LONG 0x9c mask_len
           READ_LONG 0xa0 mask_off
+          new_mask_len = 0
           INNER_PATCH_FILE ~%SAV_RES%.wed~ BEGIN
             READ_LONG    8 overlay_cnt
             READ_LONG 0x10 overlay_off


### PR DESCRIPTION
When converting the savegames an error raises:
Error: cannot convert new_mask_len or %new_mask_len% to an integer.

This indicates that the variable new_mask_len it's used out of his
scope, we fix it by declaring it at the correct scope.

This fix have been tested successfully in a Wine installation of PS:T.