### PR TITLE
patch_tis bugfixes

### DIFF
--- a/widescreen/libsmall/patch_are.tpa
+++ b/widescreen/libsmall/patch_are.tpa
@@ -1,9 +1,9 @@
 <<<<<<<< empty
-
+ 
 >>>>>>>>
-
+ 
 COPY ~empty~ ~widescreen/areas~
-
+ 
 COPY_EXISTING_REGEXP - GLOB ~^.*\.wed$~ ~...~
 	PATCH_IF SOURCE_SIZE > 0x10 BEGIN
 		READ_LONG    8 overlay_cnt
@@ -20,20 +20,22 @@ COPY_EXISTING_REGEXP - GLOB ~^.*\.wed$~ ~...~
 				whichMax = i
 			END
 		END
-		PATCH_IF (xMaxWed - 3) * 64 < biggerX || (yMaxWed - 3) * 64 < biggerY THEN BEGIN
+		PATCH_IF (xMaxWed - 3) * 64 < biggerX || (yMaxWed - 3) * 64 < biggerY && overlay_cnt > 0 THEN BEGIN
+			READ_ASCII overlay_off + whichMax * 0x18 + 4 tisFile
 			INNER_ACTION BEGIN
-				APPEND_OUTER ~widescreen/areas~ ~%SOURCE_RES% %xMaxWed% %yMaxWed%~
+				APPEND_OUTER ~widescreen/areas~ ~%SOURCE_RES% %xMaxWed% %yMaxWed% %tisFile%~
 			END
 		END
 	END
 BUT_ONLY_IF_IT_CHANGES
-
+ 
 COPY ~widescreen/areas~ ~widescreen~
 	READ_2DA_ENTRIES_NOW areas_to_fix 3
 	FOR (bfg = 0; bfg < areas_to_fix; bfg += 1) BEGIN
 		READ_2DA_ENTRY_FORMER areas_to_fix bfg 0 source_res
 		READ_2DA_ENTRY_FORMER areas_to_fix bfg 1 xMaxWed
 		READ_2DA_ENTRY_FORMER areas_to_fix bfg 2 yMaxWed
+		READ_2DA_ENTRY_FORMER areas_to_fix bfg 3 tisFile
 		origArea = xMaxWed * yMaxWed
 		xReq = biggerX / 64 + 3
 		yReq = biggerY / 64 + 3
@@ -52,7 +54,7 @@ COPY ~widescreen/areas~ ~widescreen~
 		END
 	END
 BUT_ONLY_IF_IT_CHANGES
-
+ 
 ACTION_PHP_EACH allOutDirAreas AS from => to BEGIN
 	OUTER_PATCH_SAVE thisBiff "%from_0%" BEGIN
 		REPLACE_TEXTUALLY CASE_INSENSITIVE "^AR" "TB#"

--- a/widescreen/libsmall/patch_tis.tpa
+++ b/widescreen/libsmall/patch_tis.tpa
@@ -5,7 +5,7 @@ OUTER_SET $allOutDirAreas(EVALUATE_BUFFER "%outDirAreas%") = 1
 MKDIR ~widescreen/temp~
 MKDIR ~widescreen/temp/%outDirAreas%~
 
-COPY_EXISTING ~%source_res%.tis~ ~widescreen/temp/%outDirAreas%~
+DEFINE_PATCH_MACRO edit_tis_file BEGIN
 	READ_LONG 0x08 cnt
 	READ_LONG 0x0c tiles_len
 	READ_LONG 0x10 off
@@ -13,6 +13,41 @@ COPY_EXISTING ~%source_res%.tis~ ~widescreen/temp/%outDirAreas%~
 	INSERT_BYTES off + cnt * tiles_len  tiles_len * xReq * (yReq - yMaxWed)
 	INSERT_BYTES off + cnt * tiles_len  tiles_len * yMaxWed * (xReq - xMaxWed)
 	WRITE_LONG 0x08 cnt + xReq * yReq - xMaxWed * yMaxWed
+END
+
+ACTION_IF FILE_EXISTS_IN_GAME ~%source_res%.tis~ !FILE_EXISTS ~widescreen/temp/%outDirAreas%/%source_res%.tis~ BEGIN
+	COPY_EXISTING ~%source_res%.tis~ ~widescreen/temp/%outDirAreas%~
+		LPM edit_tis_file
+END ELSE ACTION_IF !FILE_EXISTS ~widescreen/temp/%outDirAreas%/%source_res%.tis~ BEGIN
+	OUTER_SET do_it = 0
+
+	COPY_EXISTING - ~%source_res%.wed~ ~...~
+		READ_LONG    8 overlay_cnt
+		READ_LONG 0x10 overlay_off
+		__xMaxWed = 0
+		__yMaxWed = 0
+		__whichMax = 0
+		FOR (i = 0; i < overlay_cnt; i+=1) BEGIN
+			READ_SHORT overlay_off + i * 0x18 + 0 __xWed
+			READ_SHORT overlay_off + i * 0x18 + 2 __yWed
+			READ_ASCII overlay_off + i * 0x18 + 4 7c#tis_file
+			PATCH_IF xWed >= __xMaxWed && __yWed >= __yMaxWed THEN BEGIN
+				__xMaxWed = __xWed
+				__yMaxWed = __yWed
+				__whichMax = i
+			END
+		END
+		PATCH_IF (__xMaxWed - 3) * 64 < biggerX || (__yMaxWed - 3) * 64 < biggerY THEN BEGIN
+			SET do_it = 1
+		END
+		
+	ACTION_IF !FILE_EXISTS ~widescreen/temp/%outDirAreas%/%7c#tis_file%.tis~ &&
+		  FILE_EXISTS_IN_GAME ~%7c#tis_file%.wed~ && do_it
+	BEGIN
+		COPY_EXISTING ~%source_res%.tis~ ~widescreen/temp/%outDirAreas%~
+			LPM edit_tis_file
+	END
+END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~%source_res%.mos~ BEGIN
 	COPY_EXISTING ~%source_res%.mos~ ~override~

--- a/widescreen/libsmall/patch_tis.tpa
+++ b/widescreen/libsmall/patch_tis.tpa
@@ -1,11 +1,11 @@
-OUTER_PATCH_SAVE outDirAreas ~%source_res%~ BEGIN
+OUTER_PATCH_SAVE outDirAreas ~%tisFile%~ BEGIN
 	DELETE_BYTES (BUFFER_LENGTH - 1) 1
 END
 OUTER_SET $allOutDirAreas(EVALUATE_BUFFER "%outDirAreas%") = 1
 MKDIR ~widescreen/temp~
 MKDIR ~widescreen/temp/%outDirAreas%~
-
-DEFINE_PATCH_MACRO edit_tis_file BEGIN
+ 
+COPY_EXISTING ~%tisFile%.tis~ ~widescreen/temp/%outDirAreas%~
 	READ_LONG 0x08 cnt
 	READ_LONG 0x0c tiles_len
 	READ_LONG 0x10 off
@@ -13,42 +13,7 @@ DEFINE_PATCH_MACRO edit_tis_file BEGIN
 	INSERT_BYTES off + cnt * tiles_len  tiles_len * xReq * (yReq - yMaxWed)
 	INSERT_BYTES off + cnt * tiles_len  tiles_len * yMaxWed * (xReq - xMaxWed)
 	WRITE_LONG 0x08 cnt + xReq * yReq - xMaxWed * yMaxWed
-END
-
-ACTION_IF FILE_EXISTS_IN_GAME ~%source_res%.tis~ !FILE_EXISTS ~widescreen/temp/%outDirAreas%/%source_res%.tis~ BEGIN
-	COPY_EXISTING ~%source_res%.tis~ ~widescreen/temp/%outDirAreas%~
-		LPM edit_tis_file
-END ELSE ACTION_IF !FILE_EXISTS ~widescreen/temp/%outDirAreas%/%source_res%.tis~ BEGIN
-	OUTER_SET do_it = 0
-
-	COPY_EXISTING - ~%source_res%.wed~ ~...~
-		READ_LONG    8 overlay_cnt
-		READ_LONG 0x10 overlay_off
-		__xMaxWed = 0
-		__yMaxWed = 0
-		__whichMax = 0
-		FOR (i = 0; i < overlay_cnt; i+=1) BEGIN
-			READ_SHORT overlay_off + i * 0x18 + 0 __xWed
-			READ_SHORT overlay_off + i * 0x18 + 2 __yWed
-			READ_ASCII overlay_off + i * 0x18 + 4 7c#tis_file
-			PATCH_IF xWed >= __xMaxWed && __yWed >= __yMaxWed THEN BEGIN
-				__xMaxWed = __xWed
-				__yMaxWed = __yWed
-				__whichMax = i
-			END
-		END
-		PATCH_IF (__xMaxWed - 3) * 64 < biggerX || (__yMaxWed - 3) * 64 < biggerY THEN BEGIN
-			SET do_it = 1
-		END
-		
-	ACTION_IF !FILE_EXISTS ~widescreen/temp/%outDirAreas%/%7c#tis_file%.tis~ &&
-		  FILE_EXISTS_IN_GAME ~%7c#tis_file%.wed~ && do_it
-	BEGIN
-		COPY_EXISTING ~%source_res%.tis~ ~widescreen/temp/%outDirAreas%~
-			LPM edit_tis_file
-	END
-END
-
+ 
 ACTION_IF FILE_EXISTS_IN_GAME ~%source_res%.mos~ BEGIN
 	COPY_EXISTING ~%source_res%.mos~ ~override~
 		READ_ASCII 0 sig (4)


### PR DESCRIPTION
If a mod introduces a new area which is a copy of one of the game's existing areas, and instead of copying the .tis to have the new name, it only edits it's .wed to point to the old .tis, the Widescreen mod fails to install. I've fixed it in the easiest way, which is by checking whether the .tis file exists and if it doesn't, read it's reference from the .wed. Redundant checks are there to prevent re-fixing the .tis file, and .tis files without .wed files are ignored to prevent enlargening water or lava overlays.